### PR TITLE
Remove reference to ethnic diversity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Open Defense Fund for Cultural Humanity
 
-Owned by none, ODF is a consortium of organizations participating in an open forum dedicated to protecting the future of the web. No member speaks for or represents the foundation or any other member in the think tank, all views come from a diverse range of ethnic and cultural heritages.
+Owned by none, ODF is a consortium of organizations participating in an open forum dedicated to protecting the future of the web. No member speaks for or represents the foundation or any other member in the think tank, all views come from a diverse range of cultural heritages.
 
 ### Mission
 


### PR DESCRIPTION
Ethnic diversity is not relevant to the mission or values of participants. Highlighting ethnic diversity may be seen as virtue signalling — collecting woke points.